### PR TITLE
Make Responsive Navbar for Event Page

### DIFF
--- a/Workshop Page/Workshops.html
+++ b/Workshop Page/Workshops.html
@@ -159,9 +159,9 @@
           class="d-inline-block align-top" alt=""></a>
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavDropdown"
         aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
-        <span class="navbar-toggler-icon"><i class="fa fa-navicon" style="color: #ffffff; font-size: 250px;"></i></span>
+        <span class="navbar-toggler-icon"><i class="fa fa-navicon"></i></span>
       </button>
-      <div class="collapse navbar-collapse"></div>
+      
       <div class="collapse navbar-collapse" id="navbarNavDropdown">
         <ul class="navbar-nav">
           <li class="nav-item">

--- a/Workshop Page/css/Workshops.css
+++ b/Workshop Page/css/Workshops.css
@@ -1,6 +1,11 @@
 
-/***********scrollbar************/
+* {
+  
+  overflow: hidden;
+}
 
+
+/***********scrollbar************/
 
 
 /* width */
@@ -112,6 +117,11 @@
   background-image: linear-gradient(0deg, rgba(0,0,0,0.65), rgba(0,0,0,0.65));
   transition-duration: 0.75s;
   padding: 42px;
+}
+
+.event__venue__left {
+  margin-right: 40rem;
+  
 }
 
 @media (max-width: 1199px) {
@@ -792,7 +802,7 @@
     font-size: 2.25rem;
     width: auto;
     margin-top: -813px;
-    margin-right: -38px;
+    margin-right: -26px;
     margin-left: 302px;
   }
 
@@ -1009,7 +1019,7 @@
     font-size: 2.25rem;
     width: auto;
     margin-top: -484px;
-    margin-right: -36px;
+    margin-right: -26px;
     margin-left: 304px;
   }
 
@@ -1303,7 +1313,7 @@
     font-size: 2.25rem;
     width: auto;
     margin-top: -76px;
-    margin-right: -50px;
+    margin-right: -26px;
     margin-left: 306px;
   }
 }.u-section-13 .u-sheet-1 {
@@ -1535,7 +1545,7 @@
     font-size: 2.25rem;
     width: auto;
     margin-top: -1136px;
-    margin-right: -37px;
+    margin-right: -26px;
     margin-left: 303px;
   }
 }.u-section-15 .u-sheet-1 {
@@ -1652,3 +1662,4 @@
     margin-left: -10px;
   }
 }
+


### PR DESCRIPTION
Closes #10 

Made navbar of event page more responsive than before.
There are a lot of overflows in that page due to which unresponsiveness occur. I tried fixing margin of some elements which were horizontally overflowing but had to use overflow : hidden property for rest of the page because content is not getting affected and some portion of that page already have a need of unresponsiveness fix although this PR fixed the navbar issue.
Also, toggle icon was not visible for smaller screens so did some changes in it so that it would be visible.

![image](https://user-images.githubusercontent.com/30335924/226989165-617f0dfc-329e-4b8e-971a-a9dc229c1cfe.png)
![image](https://user-images.githubusercontent.com/30335924/226989323-3165660e-da83-40da-ab20-6c29f1f72f16.png)
