### PR TITLE
Arduino Image Fix

### DIFF
--- a/BLOGS/Blogs.html
+++ b/BLOGS/Blogs.html
@@ -528,7 +528,7 @@
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1"
                     xml:space="preserve" class="u-svg-content" viewBox="0 0 611.997 611.997" x="0px" y="0px"
                     id="svg-09d4" style="enable-background : new 0 0 611.997 611.997">
-                  </svg>
+                  
                   <g>
                     <g>
                       <path


### PR DESCRIPTION
Closes #5 

Arduino image is now visible. It was due to extra closing svg tag.

![image](https://user-images.githubusercontent.com/30335924/227081350-8cb474ce-f8d2-4d08-b5eb-42ac9b19635b.png)
